### PR TITLE
Add a CI/CD pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,15 +23,50 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0 
+      
+    - name: Fetch all history for all tags and branches
+      run: git fetch --prune --unshallow
 
-   # Use Nerdbank.GitVersioning to set version variables: https://github.com/AArnott/nbgv
-    - name: Use Nerdbank.GitVersioning to set version variables
-      uses: dotnet/nbgv@master
-      id: nbgv
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.2
       with:
-        setAllVars: true
+          versionSpec: '5.2.x'
+
+    - name: Use GitVersion
+      id: gitversion # step id used as reference for output values
+      uses: gittools/actions/gitversion/execute@v0.9.2
+      
+    - run: |
+        echo "Major: ${{ steps.gitversion.outputs.major }}"
+        echo "Minor: ${{ steps.gitversion.outputs.minor }}"
+        echo "Patch: ${{ steps.gitversion.outputs.patch }}"
+        echo "PreReleaseTag: ${{ steps.gitversion.outputs.preReleaseTag }}"
+        echo "PreReleaseTagWithDash: ${{ steps.gitversion.outputs.preReleaseTagWithDash }}"
+        echo "PreReleaseLabel: ${{ steps.gitversion.outputs.preReleaseLabel }}"
+        echo "PreReleaseNumber: ${{ steps.gitversion.outputs.preReleaseNumber }}"
+        echo "WeightedPreReleaseNumber: ${{ steps.gitversion.outputs.weightedPreReleaseNumber }}"
+        echo "BuildMetaData: ${{ steps.gitversion.outputs.buildMetaData }}"
+        echo "BuildMetaDataPadded: ${{ steps.gitversion.outputs.buildMetaDataPadded }}"
+        echo "FullBuildMetaData: ${{ steps.gitversion.outputs.fullBuildMetaData }}"
+        echo "MajorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}"
+        echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
+        echo "LegacySemVer: ${{ steps.gitversion.outputs.legacySemVer }}"
+        echo "LegacySemVerPadded: ${{ steps.gitversion.outputs.legacySemVerPadded }}"
+        echo "AssemblySemVer: ${{ steps.gitversion.outputs.assemblySemVer }}"
+        echo "AssemblySemFileVer: ${{ steps.gitversion.outputs.assemblySemFileVer }}"
+        echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
+        echo "InformationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}"
+        echo "BranchName: ${{ steps.gitversion.outputs.branchName }}"
+        echo "Sha: ${{ steps.gitversion.outputs.sha }}"
+        echo "ShortSha: ${{ steps.gitversion.outputs.shortSha }}"
+        echo "NuGetVersionV2: ${{ steps.gitversion.outputs.nuGetVersionV2 }}"
+        echo "NuGetVersion: ${{ steps.gitversion.outputs.nuGetVersion }}"
+        echo "NuGetPreReleaseTagV2: ${{ steps.gitversion.outputs.nuGetPreReleaseTagV2 }}"
+        echo "NuGetPreReleaseTag: ${{ steps.gitversion.outputs.nuGetPreReleaseTag }}"
+        echo "VersionSourceSha: ${{ steps.gitversion.outputs.versionSourceSha }}"
+        echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.commitsSinceVersionSource }}"
+        echo "CommitsSinceVersionSourcePadded: ${{ steps.gitversion.outputs.commitsSinceVersionSourcePadded }}"
+        echo "CommitDate: ${{ steps.gitversion.outputs.commitDate }}"
     
     - run: echo 'NuGetPackageVersion ${{ steps.nbgv.outputs.AssemblyFileVersion }}'
 
@@ -48,7 +83,7 @@ jobs:
       uses: warrenbuckley/Setup-Nuget@v1
       
     - name: Nuget Pack
-      run: nuget pack Fluent.Icons\Fluent.Icons.csproj -properties Configuration=Release;version="${{ steps.nbgv.outputs.AssemblyFileVersion }}"
+      run: nuget pack Fluent.Icons\Fluent.Icons.csproj -properties Configuration=Release;version="${{ steps.gitversion.outputs.assemblySemFileVer }}"
         
     - name: Nuget SetAPIKey
       run: nuget setApiKey ${{ secrets.NUGET_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,8 +67,6 @@ jobs:
         echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.commitsSinceVersionSource }}"
         echo "CommitsSinceVersionSourcePadded: ${{ steps.gitversion.outputs.commitsSinceVersionSourcePadded }}"
         echo "CommitDate: ${{ steps.gitversion.outputs.commitDate }}"
-    
-    - run: echo 'NuGetPackageVersion ${{ steps.nbgv.outputs.AssemblyFileVersion }}'
 
     - name: Setup MSBuild.exe
       uses: warrenbuckley/Setup-MSBuild@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,68 @@
+# This is a basic workflow to help you get started with Actions
+
+name: FluentSystemIcons.CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: 
+    - release/*
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+    
+    env:
+      USER_NAME: yoshiask
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 
+
+   # Use Nerdbank.GitVersioning to set version variables: https://github.com/AArnott/nbgv
+    - name: Use Nerdbank.GitVersioning to set version variables
+      uses: dotnet/nbgv@master
+      id: nbgv
+      with:
+        setAllVars: true
+    
+    - run: echo 'NuGetPackageVersion ${{ steps.nbgv.outputs.AssemblyFileVersion }}'
+
+    - name: Setup MSBuild.exe
+      uses: warrenbuckley/Setup-MSBuild@v1
+
+    - name: MSBuild Restore
+      run: msbuild Fluent.Icons\Fluent.Icons.csproj /p:Configuration="Release" /t:restore     
+
+    - name: MSBuild Build
+      run: msbuild Fluent.Icons\Fluent.Icons.csproj /p:Configuration="Release"
+      
+    - name: Setup Nuget.exe
+      uses: warrenbuckley/Setup-Nuget@v1
+      
+    - name: Nuget Pack
+      run: nuget pack Fluent.Icons\Fluent.Icons.csproj -properties Configuration=Release;version="${{ steps.nbgv.outputs.AssemblyFileVersion }}"
+        
+    - name: Nuget SetAPIKey
+      run: nuget setApiKey ${{ secrets.NUGET_KEY }}
+      continue-on-error: true
+
+    - name: Nuget Push
+      run: nuget push *.nupkg -Source https://api.nuget.org/v3/index.json
+      continue-on-error: true
+
+    - name: GH Nuget Add Source
+      run: nuget source Add -Name "GitHub" -Source "https://nuget.pkg.github.com/${{ env.USER_NAME }}/index.json" -UserName ${{ env.USER_NAME }} -Password ${{ secrets.GITHUB_TOKEN  }}
+      
+    - name: GH Nuget SetAPIKey
+      run: nuget setApiKey ${{ secrets.GITHUB_TOKEN  }} -Source "GitHub"      
+    
+    - name: GH Nuget Push
+      run: nuget push *.nupkg -Source "GitHub"


### PR DESCRIPTION
The CI will be triggered every time you'll merge a branch into a release/* branch (eg: release/0.1.0)

Setup

1. 

> run: nuget pack Fluent.Icons\Fluent.Icons.csproj -properties Configuration=Release;version="${{ steps.gitversion.outputs.assemblySemFileVer }}"

will create a nuget package with a git versioning based version, I used assembltSemFileVer but you can choose any other versioning variable from here https://gitversion.net/docs/more-info/variables

2. 

> run: nuget setApiKey ${{ secrets.NUGET_KEY }}

will set you nuget api key to publish the package to nuget .org, generate the api from https://www.nuget.org/account/apikeys
and add it to your github repository secrets https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets

3.

>   - name: GH Nuget Add Source      
>     - name: GH Nuget SetAPIKey
>     - name: GH Nuget Push

will publish the nuget also to github repository